### PR TITLE
no longer need stream_ prefix for sattagstream types

### DIFF
--- a/R/date2num.R
+++ b/R/date2num.R
@@ -11,7 +11,7 @@ NULL
 #' @param tz,format as expected by \code{\link[base]{as.POSIXct}}. 
 #' @param ... any other good stuff you want to pass to \code{as.POSIXct}.
 #' @details methods are defined for converting objects of a class which extends \code{sattagstream}.
-#' note that the date formats and column names are inconsistent in the data streams download from the portal. for example, note the odd capitalization patterns in \code{*-All.csv} (and ambiguous date format). method is not fully implemented for \code{stream_summary} because i've never seen the date format for \code{ReleaseDate} and \code{DeployDate}.
+#' note that the date formats and column names are inconsistent in the data streams download from the portal. for example, note the odd capitalization patterns in \code{*-All.csv} (and ambiguous date format). method is not fully implemented for \code{summary} because i've never seen the date format for \code{ReleaseDate} and \code{DeployDate}.
 #'
 #' also, beware if you open any data stream csvs in excel and re-save, the dates will likely be put into an absurb ambiguous form. additionally, seconds tend to be obliterated.
 #'
@@ -33,67 +33,67 @@ setMethod("date2num", "sattagstream", function(d, tz = "UTC", format = "%H:%M:%S
 })
 
 #' @describeIn date2num for *-All.csv. note the different time format.
-setMethod("date2num", "stream_all", function(d, tz = "UTC", format = "%m/%d/%Y %H:%M:%S", ...) {
+setMethod("date2num", "all", function(d, tz = "UTC", format = "%m/%d/%Y %H:%M:%S", ...) {
 	d$Loc..date <- date2num(d$Loc..date, tz = tz, format = format, ...)
 	d$Msg.Date  <- date2num(d$Msg.Date, tz = tz, format = format, ...)
 	d
 })
 
 #' @describeIn date2num for *-Behavior.csv
-setMethod("date2num", "stream_behavior", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
+setMethod("date2num", "behavior", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
 	d$Start <- date2num(d$Start, tz = tz, format = format, ...)
 	d$End 	<- date2num(d$End, tz = tz, format = format, ...)
 	d
 })
 
 #' @describeIn date2num for *-Corrupt.csv
-setMethod("date2num", "stream_corrupt", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
+setMethod("date2num", "corrupt", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
 	d$Date <- date2num(d$Date, tz = tz, format = format, ...)
 	d$Possible.Timestamp <- date2num(d$Possible.Timestamp, tz = tz, format = format, ...)
 	d
 })
 
 #' @describeIn date2num for *-FastGPS.csv
-setMethod("date2num", "stream_fastgps", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
+setMethod("date2num", "fastgps", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
 	d$Date <- date2num(paste(d$Time, d$Day), tz = tz, format = format, ...)
 	d
 })
 
 #' @describeIn date2num for *-Labels.csv
-setMethod("date2num", "stream_labels", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
+setMethod("date2num", "labels", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
 	warning("There aren't any dates in the labels streams")
 	d
 })
 
 #' @describeIn date2num for *-RawArgos.csv
-setMethod("date2num", "stream_rawargos", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
+setMethod("date2num", "rawargos", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
 	d$PassDate <- date2num(paste(d$PassTime, d$PassDate), tz = tz, format = format, ...)
 	d$MsgDate 	<- date2num(paste(d$MsgTime,  d$MsgDate), tz = tz, format = format, ...)
 	d
 })
 
 #' @describeIn date2num for *-RTC.csv
-setMethod("date2num", "stream_rtc", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
+setMethod("date2num", "rtc", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
 	d$TagDate  <- date2num(paste(d$TagTime,  d$TagDate), tz = tz, format = format, ...)
 	d$RealDate <- date2num(paste(d$RealTime, d$RealDate), tz = tz, format = format, ...)
 	d
 })
 
 #' @describeIn date2num for *-Series.csv
-setMethod("date2num", "stream_series", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
+setMethod("date2num", "series", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
 	d$Date <- date2num(paste(d$Time, d$Day), tz = tz, format = format, ...)
 	d
 })
 
 #' @describeIn date2num for *-SeriesRange.csv
-setMethod("date2num", "stream_seriesrange", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
+setMethod("date2num", "seriesrange", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
 	d$Start <- date2num(d$Start, tz = tz, format = format, ...)
 	d$End 	 <-	date2num(d$End, tz = tz, format = format, ...)
 	d
 })
 
 #' @describeIn date2num for *-Locations.csv
-setMethod("date2num", "stream_locations", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
+setMethod("date2num", "locations", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
 	tmpdate <- d$Date
 	datesplit <- strsplit(tmpdate, " ")
 	times <- sapply(datesplit, "[[", 1)
@@ -106,14 +106,14 @@ setMethod("date2num", "stream_locations", function(d, tz = "UTC", format = "%H:%
 })
 
 #' @describeIn date2num for *-Status.csv
-setMethod("date2num", "stream_status", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
+setMethod("date2num", "status", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
 	d$Received <- date2num(d$Received, tz = tz, format = format, ...)
 	d$RTC 		<- 	date2num(d$RTC, tz = tz, format = format, ...)
 	d
 })
 
 #' @describeIn date2num for *-Summary.csv note: not sure how to implement ReleaseDate or DeployDate...
-setMethod("date2num", "stream_summary", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
+setMethod("date2num", "summary", function(d, tz = "UTC", format = "%H:%M:%S %d-%b-%Y", ...) {
 	d$EarliestXmitTime	<- date2num(d$EarliestXmitTime, tz = tz, format = format, ...)
 	d$LatestXmitTime	<- date2num(d$LatestXmitTime, tz = tz, format = format, ...)
 	d$EarliestDataTime <- date2num(d$EarliestDataTime, tz = tz, format = format, ...)

--- a/R/sattag.R
+++ b/R/sattag.R
@@ -200,7 +200,6 @@ setMethod("getstream", "sattag", function(x, type, collapse = FALSE) {
     x <- do.call('rbind', x)
     row.names(x) <- 1:nrow(x)
 
-    type <- strsplit(type, split = "_")[[1]][2]
     x <- sattagstream(type, data = x, filename = fnames)
   }
 x

--- a/R/sattagstream.R
+++ b/R/sattagstream.R
@@ -40,8 +40,6 @@ sattagstream <- function(type = character(), data = data.frame(), filename = cha
 	type <- tolower(type)
 	if(!(type %in% subclassoptions)) {
 		type <- "sattagstream"
-	} else {
-		type <- paste0("stream_", type)
 	}
 	
 	new(type, streamtype = type, data, filename = filename)

--- a/R/sattagstream_extends.R
+++ b/R/sattagstream_extends.R
@@ -7,7 +7,7 @@ NULL
 #' @seealso \code{\link[sattagutils]{sattag-class}} 
 #' @seealso \code{\link[sattagutils]{sattagstream-class}}
 #' @family sattagstream types
-setClass("stream_all", 			contains = "sattagstream")
+setClass("all", 			contains = "sattagstream")
 
 #' an S4 class which extends sattagstream
 #'
@@ -15,7 +15,7 @@ setClass("stream_all", 			contains = "sattagstream")
 #' @seealso \code{\link[sattagutils]{sattag-class}} 
 #' @seealso \code{\link[sattagutils]{sattagstream-class}}
 #' @family sattagstream types
-setClass("stream_argos", 		contains = "sattagstream")
+setClass("argos", 		contains = "sattagstream")
 
 #' an S4 class which extends sattagstream
 #'
@@ -23,7 +23,7 @@ setClass("stream_argos", 		contains = "sattagstream")
 #' @seealso \code{\link[sattagutils]{sattag-class}} 
 #' @seealso \code{\link[sattagutils]{sattagstream-class}}
 #' @family sattagstream types
-setClass("stream_behavior", 		contains = "sattagstream")
+setClass("behavior", 		contains = "sattagstream")
 
 #' an S4 class which extends sattagstream
 #'
@@ -31,7 +31,7 @@ setClass("stream_behavior", 		contains = "sattagstream")
 #' @seealso \code{\link[sattagutils]{sattag-class}} 
 #' @seealso \code{\link[sattagutils]{sattagstream-class}}
 #' @family sattagstream types
-setClass("stream_corrupt", 		contains = "sattagstream")
+setClass("corrupt", 		contains = "sattagstream")
 
 #' an S4 class which extends sattagstream
 #'
@@ -39,7 +39,7 @@ setClass("stream_corrupt", 		contains = "sattagstream")
 #' @seealso \code{\link[sattagutils]{sattag-class}} 
 #' @seealso \code{\link[sattagutils]{sattagstream-class}}
 #' @family sattagstream types
-setClass("stream_fastgps", 		contains = "sattagstream")
+setClass("fastgps", 		contains = "sattagstream")
 
 #' an S4 class which extends sattagstream
 #'
@@ -47,7 +47,7 @@ setClass("stream_fastgps", 		contains = "sattagstream")
 #' @seealso \code{\link[sattagutils]{sattag-class}} 
 #' @seealso \code{\link[sattagutils]{sattagstream-class}}
 #' @family sattagstream types
-setClass("stream_histos", 		contains = "sattagstream")
+setClass("histos", 		contains = "sattagstream")
 
 #' an S4 class which extends sattagstream
 #'
@@ -55,7 +55,7 @@ setClass("stream_histos", 		contains = "sattagstream")
 #' @seealso \code{\link[sattagutils]{sattag-class}} 
 #' @seealso \code{\link[sattagutils]{sattagstream-class}}
 #' @family sattagstream types
-setClass("stream_labels", 		contains = "sattagstream")
+setClass("labels", 		contains = "sattagstream")
 
 #' an S4 class which extends sattagstream
 #'
@@ -63,7 +63,7 @@ setClass("stream_labels", 		contains = "sattagstream")
 #' @seealso \code{\link[sattagutils]{sattag-class}} 
 #' @seealso \code{\link[sattagutils]{sattagstream-class}}
 #' @family sattagstream types
-setClass("stream_locations", 	contains = "sattagstream")
+setClass("locations", 	contains = "sattagstream")
 
 #' an S4 class which extends sattagstream
 #'
@@ -71,7 +71,7 @@ setClass("stream_locations", 	contains = "sattagstream")
 #' @seealso \code{\link[sattagutils]{sattag-class}} 
 #' @seealso \code{\link[sattagutils]{sattagstream-class}}
 #' @family sattagstream types
-setClass("stream_minmaxdepth",	contains = "sattagstream")
+setClass("minmaxdepth",	contains = "sattagstream")
 
 #' an S4 class which extends sattagstream
 #'
@@ -79,7 +79,7 @@ setClass("stream_minmaxdepth",	contains = "sattagstream")
 #' @seealso \code{\link[sattagutils]{sattag-class}} 
 #' @seealso \code{\link[sattagutils]{sattagstream-class}}
 #' @family sattagstream types
-setClass("stream_rawargos", 		contains = "sattagstream")
+setClass("rawargos", 		contains = "sattagstream")
 
 #' an S4 class which extends sattagstream
 #'
@@ -87,7 +87,7 @@ setClass("stream_rawargos", 		contains = "sattagstream")
 #' @seealso \code{\link[sattagutils]{sattag-class}} 
 #' @seealso \code{\link[sattagutils]{sattagstream-class}}
 #' @family sattagstream types
-setClass("stream_rtc", 			contains = "sattagstream")
+setClass("rtc", 			contains = "sattagstream")
 
 #' an S4 class which extends sattagstream
 #'
@@ -95,7 +95,7 @@ setClass("stream_rtc", 			contains = "sattagstream")
 #' @seealso \code{\link[sattagutils]{sattag-class}} 
 #' @seealso \code{\link[sattagutils]{sattagstream-class}}
 #' @family sattagstream types
-setClass("stream_series", 		contains = "sattagstream")
+setClass("series", 		contains = "sattagstream")
 
 #' an S4 class which extends sattagstream
 #'
@@ -103,7 +103,7 @@ setClass("stream_series", 		contains = "sattagstream")
 #' @seealso \code{\link[sattagutils]{sattag-class}} 
 #' @seealso \code{\link[sattagutils]{sattagstream-class}}
 #' @family sattagstream types
-setClass("stream_seriesrange", 	contains = "sattagstream")
+setClass("seriesrange", 	contains = "sattagstream")
 
 #' an S4 class which extends sattagstream
 #'
@@ -111,7 +111,7 @@ setClass("stream_seriesrange", 	contains = "sattagstream")
 #' @seealso \code{\link[sattagutils]{sattag-class}} 
 #' @seealso \code{\link[sattagutils]{sattagstream-class}}
 #' @family sattagstream types
-setClass("stream_sst", 			contains = "sattagstream")
+setClass("sst", 			contains = "sattagstream")
 
 #' an S4 class which extends sattagstream
 #'
@@ -119,7 +119,7 @@ setClass("stream_sst", 			contains = "sattagstream")
 #' @seealso \code{\link[sattagutils]{sattag-class}} 
 #' @seealso \code{\link[sattagutils]{sattagstream-class}}
 #' @family sattagstream types
-setClass("stream_status", 		contains = "sattagstream")
+setClass("status", 		contains = "sattagstream")
 
 #' an S4 class which extends sattagstream
 #'
@@ -127,4 +127,4 @@ setClass("stream_status", 		contains = "sattagstream")
 #' @seealso \code{\link[sattagutils]{sattag-class}} 
 #' @seealso \code{\link[sattagutils]{sattagstream-class}}
 #' @family sattagstream types
-setClass("stream_summary", 		contains = "sattagstream")
+setClass("summary", 		contains = "sattagstream")

--- a/R/ser2beh.R
+++ b/R/ser2beh.R
@@ -24,7 +24,7 @@ ser2beh <- function(
 	
 	
 	# error checking
-	if(is.sattagstream(s) & streamtype(s) != "stream_series") {
+	if(is.sattagstream(s) & streamtype(s) != "series") {
 		stop("if you're gonna use a sattagstream it's gotta be a series...")
 	}		
 	

--- a/R/tagstack.R
+++ b/R/tagstack.R
@@ -114,7 +114,6 @@ setMethod("getstream", "tagstack", function(x, type, collapse = FALSE) {
     out <- do.call('rbind', lapply(out, function(l) do.call('rbind', l)))
     row.names(out) <- 1:nrow(out)
 
-    type <- strsplit(type, split = "_")[[1]][2]
     out <- sattagstream(type, data = out, filename = fnames)
   }
   out


### PR DESCRIPTION
sattagstream() expended type to be e.g., "stream_series" but getstream expected e.g., "series" removed the stream_ prefix everywhere for consistency.