### PR TITLE
sort_by_message function for behavior sattagstreams

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - `load\_dap\_output` function for loading a directory with DAP / Argos Message Decoder output and returning a tagstack
 - `merge_stacks` function for merging two tagstacks together and combining matching sattagstreams where possible.
 - `duplicated_sattagstream` used by `merge_stacks` to look for duplicates in different streamtypes
+- `sort_by_message` a function for sorting behavior sattagstreams while respecting messages.
 
 ## MAJOR CHANGES
 

--- a/R/sort_by_message.R
+++ b/R/sort_by_message.R
@@ -1,0 +1,29 @@
+#' sort behavior streams
+#' 
+#' sort behavior streams by start time keeping messages together
+#' @param beh a beavior sattagstream.
+#' @return a behavior sattagstream sorted.
+#' @export
+
+sort_by_message <- function(beh) {
+  if(streamtype(beh) != "behavior") stop("beh must be a behavior sattagstream...")
+  
+  msgid <- cumsum(beh$What == "Message")
+  nmsg <- length(unique(umsgid))
+  
+  msgorder <- order(beh$Start[beh$What == "Message"])
+  runlen <- rle(msgid)$lengths
+  
+  msgsort <- vector("list", length = nmsg)
+  
+  k <- 1
+  for(i in 1:length(runlen)) {
+    st <- k
+    k <- k + runlen[i]
+    en <- k - 1
+    msgsort[[i]] <- st:en
+  }
+  
+  oo <- unlist(msgsort[msgorder])
+  beh[oo, ]
+}


### PR DESCRIPTION
respects the message block even if there are strange timing errors between messages. Will sort by message start time only and not interview within a message block.